### PR TITLE
Fix bug with activity timestamps

### DIFF
--- a/lib/Business/UPS/Tracking/Utils.pm
+++ b/lib/Business/UPS/Tracking/Utils.pm
@@ -177,7 +177,7 @@ sub parse_time {
             error   => "Invalid time string: ".$_,
             xml     => $timestr,
         );
-    }
+    };
 
     return $datetime;
 }

--- a/t/03_simplerequest.t
+++ b/t/03_simplerequest.t
@@ -84,5 +84,5 @@ SKIP:{
     is($activity1->StatusType->Description,'DELIVERED','Activity 1 status type description is ok');
     is($activity1->StatusCode,'KM','Activity 1 status code description is ok');
     isa_ok($activity1->DateTime,'DateTime');
-    is($activity1->DateTime->format_cldr('yyyy.MM.dd HH:mm:ss'),'2010.06.10 00:00:00','Activity 1 datetime is ok');
+    is($activity1->DateTime->format_cldr('yyyy.MM.dd HH:mm:ss'),'2010.06.10 12:00:00','Activity 1 datetime is ok');
 }

--- a/t/06_utils.t
+++ b/t/06_utils.t
@@ -1,0 +1,18 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::NoWarnings;
+use Test::More tests => 1;
+
+use lib qw(t/);
+use testlib;
+
+use DateTime;
+use Business::UPS::Tracking::Utils;
+
+my $d  = DateTime->new( year => 2018, month => 6, day => 27 );
+my $dt = Business::UPS::Tracking::Utils::parse_time( "123000", $d);
+is( $dt->strftime("%Y-%m-%d %H:%M:%S"), "2018-06-27 12:30:00" );
+


### PR DESCRIPTION
There was a small bug in the time parsing logic that caused activity timestamps to always generate as 00:00:00, this fixes that.